### PR TITLE
Rename "Kubernetes" to "Deployment" example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -311,7 +311,7 @@ A policy to update only minor releases:
 keel.sh/policy=minor
 ```
 
-### Kubernetes example
+### Deployment example
 
 Here is an example application `deployment.yaml` where we instruct Keel to update container image whenever there is a new version:
 


### PR DESCRIPTION
Because that's what this chapter documents, as opposed to the StatefulSet & DaemonSet examples in the following sections.